### PR TITLE
Removed trailing comma from states object

### DIFF
--- a/ontobox.js
+++ b/ontobox.js
@@ -84,7 +84,7 @@
         // the user opened the box but did not yet hover over it
         opened: 0,
         // the user hovered over the box
-        hovered: 1,
+        hovered: 1
     };
 
 


### PR DESCRIPTION
Trailing commas are not fully supported in older versions of javascript (< ES5).
See link: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas)